### PR TITLE
Fix scoreboard heap update logic

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ app.add_middleware(
 )
 
 # In-memory scoreboard up to top 10
+# scoreboard_heap stores (score, name) as a min-heap
 scoreboard_heap = []
 
 class ScoreItem(BaseModel):
@@ -41,18 +42,19 @@ def root():
 
 @app.get("/scoreboard")
 def get_scoreboard():
-    # return up to top 10
-    sorted_scores = sorted(scoreboard_heap, key=lambda x: x[0])
+    # return top 10 scores in descending order
+    sorted_scores = sorted(scoreboard_heap, key=lambda x: x[0], reverse=True)
     top_scores = []
     for sc, nm in sorted_scores[:10]:
-        top_scores.append({"name": nm, "score": -sc})
+        top_scores.append({"name": nm, "score": sc})
     return {"topScores": top_scores}
 
 @app.post("/scoreboard")
 def post_scoreboard(item: ScoreItem):
-    # push (neg score, name)
-    heapq.heappush(scoreboard_heap, (-item.score, item.name))
+    # Push score/name pair and keep only the top 10
+    heapq.heappush(scoreboard_heap, (item.score, item.name))
     if len(scoreboard_heap) > 10:
+        # Remove the lowest score so only the highest remain
         heapq.heappop(scoreboard_heap)
     return JSONResponse({"message": "Score saved"})
 


### PR DESCRIPTION
## Summary
- ensure scoreboard heap stores positive scores
- sort scores in descending order for retrieval
- keep highest scores when heap exceeds 10 entries

## Testing
- `python -m py_compile backend/main.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684001fbc734832483c6970abb386536